### PR TITLE
feat: Add function for imorting unrolled img from rint rapid2

### DIFF
--- a/Crystallography/Images/ImageIO.cs
+++ b/Crystallography/Images/ImageIO.cs
@@ -1298,7 +1298,7 @@ public static class ImageIO
 
     #endregion
 
-    #region Unroll image from Rigaku RINT-RAPID II
+    #region Unrolled image from Rigaku RINT-RAPID II
     public static bool RintRapid2Unroll(string str, uint[] convertTable = null)
     {
         try
@@ -1327,9 +1327,9 @@ public static class ImageIO
             br.BaseStream.Position = 17408; // HEADER_BYTES 分読み取った後の位置にセット
             int length = num_x_pixs * num_y_pixs;
 
-            // 直観的な方法。検証が必要。
+            // ヘッダ部分にData_type = unsigned short int;と書かれていた。
             for (int i = 0; i < length; i++)
-                Ring.Intensity.Add(convertTable[br.ReadUInt16()]); // ヘッダ部分にData_type = unsigned short int;と書かれていた。
+                Ring.Intensity.Add(convertTable[br.ReadUInt16()]); 
 
         }
         catch (Exception e)

--- a/Crystallography/Images/ImageIO.cs
+++ b/Crystallography/Images/ImageIO.cs
@@ -1307,11 +1307,22 @@ public static class ImageIO
 
             //ヘッダ部分読み込み
             Ring.Comments = "";
-            br.BaseStream.Position = 0;
-            Ring.Comments += new string(br.ReadChars(10));//Device
             br.BaseStream.Position = 0; // 初期位置にセット
             string headerText = new string(br.ReadChars(17408)); // HEADER_BYTES 分読み取る
-                                                                 // 正規表現でSIZE1とSIZE2を検索
+                                                                 // 正規表現で検索
+            Match matchMemo = Regex.Match(headerText, @"MEMO=([^;]+);"); // Device
+            Ring.Comments += "\r\n" + matchMemo.Groups[1].Value;
+            Match matchVersion = Regex.Match(headerText, @"DTREK_VERSION=([^;]+);"); // Version
+            Ring.Comments += "\r\n" + matchVersion.Groups[1].Value;
+            Match matchSample = Regex.Match(headerText, @"SAMPLE_NAME=([^;]+);"); // Sample
+            Ring.Comments += "\r\n" + matchSample.Groups[1].Value;
+            Match matchDate = Regex.Match(headerText, @"RX_CREATE_DATE=([^;]+);"); // Date
+            Ring.Comments += "\r\n" + matchDate.Groups[1].Value;
+            Match matchOperator = Regex.Match(headerText, @"OPERATOR_NAME=([^;]+);"); // Operator
+            Ring.Comments += "\r\n" + matchOperator.Groups[1].Value;
+            Match matchTarget = Regex.Match(headerText, @"SOURCE_TARGET=([^;]+);"); // Target
+            Ring.Comments += "\r\n" + matchTarget.Groups[1].Value;
+
             Match matchSize1 = Regex.Match(headerText, @"SIZE1=(\d+);");
             Match matchSize2 = Regex.Match(headerText, @"SIZE2=(\d+);");
 

--- a/Crystallography/Images/ImageIO.cs
+++ b/Crystallography/Images/ImageIO.cs
@@ -5,6 +5,7 @@ using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using System.Xml.Serialization;
 
@@ -92,6 +93,14 @@ public static class ImageIO
         return temp == "R-AXIS" || temp == "ipdsc\0";
     }
 
+    public static bool IsRintRapid2UnrollImage(string fileName)
+    {
+        var br = new BinaryReader(new FileStream(fileName, FileMode.Open, FileAccess.Read));
+        br.BaseStream.Position = 0;
+        var temp = new string(br.ReadChars(46));
+        br.Close();
+        return temp == "{\nHEADER_BYTES=17408;\nBYTE_ORDER=little_endian";
+    }
     public static bool IsITEXImage(string fileName)
     {
         var br = new BinaryReader(new FileStream(fileName, FileMode.Open, FileAccess.Read));
@@ -185,6 +194,8 @@ public static class ImageIO
                 result = FujiFDL(str);
             else if (IsRAxisImage(str))//R-Axis5
                 result = Raxis4(str);
+            else if (IsRintRapid2UnrollImage(str))//Rigaku RINT-RAPID II
+                result = RintRapid2Unroll(str);
             else if (IsADXVImage(str))
                 result = ADXV(str);
             else if (IsITEXImage(str))
@@ -1276,6 +1287,50 @@ public static class ImageIO
                 Ring.ImageType = Ring.ImageTypeEnum.Rigaku_RAxis_IV;
 
             br.Close();
+        }
+        catch (Exception e)
+        {
+            MessageBox.Show(e.Message);
+            return false;
+        }
+        return true;
+    }
+
+    #endregion
+
+    #region Unroll image from Rigaku RINT-RAPID II
+    public static bool RintRapid2Unroll(string str, uint[] convertTable = null)
+    {
+        try
+        {
+            var br = new BinaryReader(new FileStream(str, FileMode.Open, FileAccess.Read));
+
+            //ヘッダ部分読み込み
+            Ring.Comments = "";
+            br.BaseStream.Position = 0;
+            Ring.Comments += new string(br.ReadChars(10));//Device
+            br.BaseStream.Position = 0; // 初期位置にセット
+            string headerText = new string(br.ReadChars(17408)); // HEADER_BYTES 分読み取る
+                                                                 // 正規表現でSIZE1とSIZE2を検索
+            Match matchSize1 = Regex.Match(headerText, @"SIZE1=(\d+);");
+            Match matchSize2 = Regex.Match(headerText, @"SIZE2=(\d+);");
+
+            int num_x_pixs = int.Parse(matchSize1.Groups[1].Value); // Number of pixel X
+            int num_y_pixs = int.Parse(matchSize2.Groups[1].Value); // Number of pixel Y
+            Ring.SrcImgSize = new Size(num_x_pixs, num_y_pixs);
+            
+            convertTable = new uint[65536];
+            for (uint i = 0; i < 65536; i++)
+                convertTable[i] = i;
+
+            //イメージデータ読みこみ
+            br.BaseStream.Position = 17408; // HEADER_BYTES 分読み取った後の位置にセット
+            int length = num_x_pixs * num_y_pixs;
+
+            // 直観的な方法。検証が必要。
+            for (int i = 0; i < length; i++)
+                Ring.Intensity.Add(convertTable[br.ReadUInt16()]); // ヘッダ部分にData_type = unsigned short int;と書かれていた。
+
         }
         catch (Exception e)
         {


### PR DESCRIPTION
### What  
Added support for importing unrolled image data exported by Rigaku's 2DP software.

### Why  
Enabling the import of unrolled data allows users to convert the image into other formats, making it easier to perform their own analyses using external tools.

### How  
Added the following logic to `ImageIO.cs`:  
- Detects whether the imported file is an image unrolled by 2DP  
- Parses the file header using regular expressions to extract the image dimensions

### Visuals  
![IPAnalyzer_demo_feat_read_unrollimg](https://github.com/user-attachments/assets/2a080f35-34b8-4b6b-b8ef-6ca28b64d970)


### TODO / Known Limitations  
~~The information shown in the **Image Information** panel of the GUI has not been fully reviewed yet~~. 
~~I plan to investigate and refine which metadata should be included in `Ring.Comments` within `ImageIO.cs`.~~

(2025/04/20) In commit [`a283632`](https://github.com/seto77/IPAnalyzer/pull/5/commits/a2836323c7ff4bcf3e312eea52d76d035156666e), I modified the code to read and display the following metadata fields: `Device`, `Version`, `Sample`, `Date`, `Operator`, and `Target`.

### Others  
- **Note**: Tests have not been run yet.
If there are any existing automated tests (such as unit tests or UI tests), please let me know — I’d be happy to run them on my side as well.

- I'm slightly concerned that this change may have unintended side effects. Feedback or suggestions are very welcome!


Close seto77/IPAnalyzer#4
